### PR TITLE
Change project name to cb-grunt-cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,22 @@
 {
-  "name": "grunt-cdn",
+  "name": "cb-grunt-cdn",
   "description": "Properly prepends a CDN url to those assets referenced with absolute paths (but not URLs)",
-  "version": "0.2.2",
-  "homepage": "https://github.com/tactivos/grunt-cdn",
+  "version": "0.1.0",
+  "private": true,
   "author": {
     "name": "Johnny Halife",
     "url": "http://github.com/johnnyhalife/"
   },
+  "contributors": [
+    {
+      "name": "Mark Kinsella",
+      "email": "mark@chartboost.com",
+      "url": "http://github.com/mkinsella/"
+    }
+  ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/tactivos/grunt-cdn.git"
-  },
-  "bugs": {
-    "url": "https://github.com/tactivos/grunt-cdn/issues"
+    "url": "git://github.com/ChartBoost/grunt-cdn.git"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Reset project to a Chartboost-specific dependency.
- Change name to `cb-grunt-cdn`
- Reset version to v0.1.0
- Set as a private dependency
- Update URLs
- Add contributor
